### PR TITLE
Delayed hints

### DIFF
--- a/src-alcotest/imandra_goals_alcotest.ml
+++ b/src-alcotest/imandra_goals_alcotest.ml
@@ -1,4 +1,4 @@
-open Imandra_goals
+open Imandra_goals [@@warning "-45"]
 
 let expected_to_string : expected -> string = function
   | True -> "True"

--- a/src/imandra_goals.ml
+++ b/src/imandra_goals.ml
@@ -12,7 +12,7 @@ type t = {
   expected: expected;
   mode: mode;
   idx: int;
-  hints: Imandra_surface.Uid.t Imandra_surface.Hints.t option;
+  hints: (unit -> Imandra_surface.Uid.t Imandra_surface.Hints.t) option;
   model_candidates: string list;
   upto: Imandra_syntax.Logic_ast.upto option;
 }
@@ -148,7 +148,7 @@ let close_goal ?hints g =
   in
   let hints =
     match hints with
-    | None -> g.hints
+    | None -> g.hints |> CCOption.map (fun mk -> mk ())
     | Some _ -> hints
   in
   try

--- a/src/imandra_goals.mli
+++ b/src/imandra_goals.mli
@@ -9,7 +9,7 @@ type t = {
   expected: expected;
   mode: mode;
   idx: int;
-  hints: Imandra_surface.Uid.t Imandra_surface.Hints.t option;
+  hints: (unit -> Imandra_surface.Uid.t Imandra_surface.Hints.t) option;
   model_candidates: string list;
   upto: Imandra_syntax.Logic_ast.upto option;
 }
@@ -44,7 +44,7 @@ val init :
   ?owner:owner ->
   ?expected:expected ->
   ?mode:mode ->
-  ?hints:Imandra_surface.Uid.t Imandra_surface.Hints.t ->
+  ?hints:(unit -> Imandra_surface.Uid.t Imandra_surface.Hints.t) ->
   ?upto:Imandra_syntax.Logic_ast.upto ->
   ?model_candidates:string list ->
   desc:string ->


### PR DESCRIPTION
Allows defining `Goal`s and hints in the same module, e.g.:

```ocaml
(* my_goals.iml *)

let hint_1 x = ...

let goal_1 x = ...

let () =
  Imandra_goals.init ~name:"My_goals.goal_1" ~desc:"A goal" ()
    ~hints:Hints.(fun () ->
      auto |> add_apply_hints [ DB.id_of_str (db ()) "My_goals.hint_1" ])
  [@@program]
```
We can then import the module and close the goals:

```ocaml
# #import "./my_goals.iml";;
# Imandra_goals.(all () |> Caml.List.iter (fun (_id, g) -> close_goal g |> ignore))[@@program];;
```

Imandra imports the events in batch, so `hint_1` is not yet defined in the DB when `Imandra_goals.init` is called. Hence the need to delay evaluation of `~hints`.

